### PR TITLE
Switch site.url to https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 ###########
 # site.url, site.title
 
-url:   'http://planetruby.github.io'
+url:   'https://planetruby.github.io'
 title: 'Planet Ruby'
 
 ########


### PR DESCRIPTION
As GitHub pages now prefers to serve files via HTTPS by default, switch the site.url in _config.yml in order to fix CSS and possibly JS insecure origin errors in browsers.